### PR TITLE
refactor: rename check functions

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -40,3 +40,6 @@ WORKDIR /workspaces/onekit
 COPY . .
 RUN poetry install \
     && rm -rf ~/.cache/pypoetry/{cache,artifacts}
+
+# install pre-commit
+RUN pre-commit install

--- a/docs/source/examples.ipynb
+++ b/docs/source/examples.ipynb
@@ -81,7 +81,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Sun, 1 Jan 2023 12:00:00 -> Sun, 1 Jan 2023 12:00:00 = 0.100701s - example 1\n"
+      "Sun, 1 Jan 2023 12:00:00 -> Sun, 1 Jan 2023 12:00:00 = 0.100557s - example 1\n"
      ]
     }
    ],
@@ -107,14 +107,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Sun, 1 Jan 2023 12:00:00 -> Sun, 1 Jan 2023 12:00:00 = 0.050445s - example 2 - stopwatch 1\n",
-      "Sun, 1 Jan 2023 12:00:00 -> Sun, 1 Jan 2023 12:00:00 = 0.050392s - example 2 - stopwatch 2\n"
+      "Sun, 1 Jan 2023 12:00:00 -> Sun, 1 Jan 2023 12:00:00 = 0.050664s - example 2 - stopwatch 1\n",
+      "Sun, 1 Jan 2023 12:00:00 -> Sun, 1 Jan 2023 12:00:00 = 0.050194s - example 2 - stopwatch 2\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "0.100837s - total elapsed time"
+       "0.100858s - total elapsed time"
       ]
      },
      "execution_count": 4,
@@ -159,7 +159,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Sun, 1 Jan 2023 12:00:00 -> Sun, 1 Jan 2023 12:00:00 = 0.100617s - example 3\n"
+      "Sun, 1 Jan 2023 12:00:00 -> Sun, 1 Jan 2023 12:00:00 = 0.100435s - example 3\n"
      ]
     }
    ],
@@ -187,7 +187,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Sun, 1 Jan 2023 12:00:00 -> Sun, 1 Jan 2023 12:00:00 = 0.100502s - func_with_no_supplied_label\n"
+      "Sun, 1 Jan 2023 12:00:00 -> Sun, 1 Jan 2023 12:00:00 = 0.100264s - func_with_no_supplied_label\n"
      ]
     }
    ],
@@ -281,7 +281,7 @@
      "output_type": "stream",
      "text": [
       "Traceback (most recent call last):\n",
-      "  File \"/tmp/ipykernel_37373/54865336.py\", line 2, in <module>\n",
+      "  File \"/tmp/ipykernel_29965/54865336.py\", line 2, in <module>\n",
       "    assert lft_str == rgt_str, f\"{lft_str} != {rgt_str}\"\n",
       "AssertionError: hello != hallo\n"
      ]
@@ -311,7 +311,7 @@
      "output_type": "stream",
      "text": [
       "Traceback (most recent call last):\n",
-      "  File \"/tmp/ipykernel_37373/788221307.py\", line 6, in <module>\n",
+      "  File \"/tmp/ipykernel_29965/788221307.py\", line 6, in <module>\n",
       "    assert lft_str == rgt_str, get_string_diff(lft_str, rgt_str)\n",
       "AssertionError: lft_str != rgt_str\n",
       "hello\n",
@@ -609,7 +609,7 @@
       "WARNING: Please consider reporting this to the maintainers of org.apache.spark.unsafe.Platform\n",
       "WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations\n",
       "WARNING: All illegal access operations will be denied in a future release\n",
-      "23/12/12 22:36:53 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable\n",
+      "24/03/03 16:25:06 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable\n",
       "Using Spark's default log4j profile: org/apache/spark/log4j-defaults.properties\n",
       "Setting default log level to \"WARN\".\n",
       "To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).\n"
@@ -789,7 +789,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### `check_schema_equal`"
+    "### `assert_schema_equal`"
    ]
   },
   {
@@ -804,8 +804,8 @@
      "traceback": [
       "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
       "\u001b[0;31mSchemaMismatchError\u001b[0m                       Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[25], line 3\u001b[0m\n\u001b[1;32m      1\u001b[0m lft_df \u001b[38;5;241m=\u001b[39m spark\u001b[38;5;241m.\u001b[39mcreateDataFrame([\u001b[38;5;28mdict\u001b[39m(x\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m1\u001b[39m, y\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m2\u001b[39m), \u001b[38;5;28mdict\u001b[39m(x\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m3\u001b[39m, y\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m4\u001b[39m)])\n\u001b[1;32m      2\u001b[0m rgt_df \u001b[38;5;241m=\u001b[39m spark\u001b[38;5;241m.\u001b[39mcreateDataFrame([\u001b[38;5;28mdict\u001b[39m(x\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m1\u001b[39m), \u001b[38;5;28mdict\u001b[39m(x\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m3\u001b[39m)])\n\u001b[0;32m----> 3\u001b[0m \u001b[43msk\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcheck_schema_equal\u001b[49m\u001b[43m(\u001b[49m\u001b[43mlft_df\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mrgt_df\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m/workspaces/onekit/src/onekit/sparkkit.py:340\u001b[0m, in \u001b[0;36mcheck_schema_equal\u001b[0;34m(lft_df, rgt_df)\u001b[0m\n\u001b[1;32m    337\u001b[0m rgt_schema \u001b[38;5;241m=\u001b[39m rgt_df\u001b[38;5;241m.\u001b[39mschema\u001b[38;5;241m.\u001b[39msimpleString()\n\u001b[1;32m    339\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m lft_schema \u001b[38;5;241m!=\u001b[39m rgt_schema:\n\u001b[0;32m--> 340\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m SchemaMismatchError(lft_schema, rgt_schema)\n",
+      "Cell \u001b[0;32mIn[25], line 3\u001b[0m\n\u001b[1;32m      1\u001b[0m lft_df \u001b[38;5;241m=\u001b[39m spark\u001b[38;5;241m.\u001b[39mcreateDataFrame([\u001b[38;5;28mdict\u001b[39m(x\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m1\u001b[39m, y\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m2\u001b[39m), \u001b[38;5;28mdict\u001b[39m(x\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m3\u001b[39m, y\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m4\u001b[39m)])\n\u001b[1;32m      2\u001b[0m rgt_df \u001b[38;5;241m=\u001b[39m spark\u001b[38;5;241m.\u001b[39mcreateDataFrame([\u001b[38;5;28mdict\u001b[39m(x\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m1\u001b[39m), \u001b[38;5;28mdict\u001b[39m(x\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m3\u001b[39m)])\n\u001b[0;32m----> 3\u001b[0m \u001b[43msk\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43massert_schema_equal\u001b[49m\u001b[43m(\u001b[49m\u001b[43mlft_df\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mrgt_df\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m/workspaces/onekit/src/onekit/sparkkit.py:330\u001b[0m, in \u001b[0;36massert_schema_equal\u001b[0;34m(lft_df, rgt_df)\u001b[0m\n\u001b[1;32m    327\u001b[0m rgt_schema \u001b[38;5;241m=\u001b[39m rgt_df\u001b[38;5;241m.\u001b[39mschema\u001b[38;5;241m.\u001b[39msimpleString()\n\u001b[1;32m    329\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m lft_schema \u001b[38;5;241m!=\u001b[39m rgt_schema:\n\u001b[0;32m--> 330\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m SchemaMismatchError(lft_schema, rgt_schema)\n",
       "\u001b[0;31mSchemaMismatchError\u001b[0m: n_diff=10\nstruct<x:bigint,y:bigint>\n               ||||||||||\nstruct<x:bigint>"
      ]
     }
@@ -813,14 +813,14 @@
    "source": [
     "lft_df = spark.createDataFrame([dict(x=1, y=2), dict(x=3, y=4)])\n",
     "rgt_df = spark.createDataFrame([dict(x=1), dict(x=3)])\n",
-    "sk.check_schema_equal(lft_df, rgt_df)"
+    "sk.assert_schema_equal(lft_df, rgt_df)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### `check_row_count_equal`"
+    "### `assert_row_count_equal`"
    ]
   },
   {
@@ -835,8 +835,8 @@
      "traceback": [
       "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
       "\u001b[0;31mRowCountMismatchError\u001b[0m                     Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[26], line 3\u001b[0m\n\u001b[1;32m      1\u001b[0m lft_df \u001b[38;5;241m=\u001b[39m spark\u001b[38;5;241m.\u001b[39mcreateDataFrame([\u001b[38;5;28mdict\u001b[39m(x\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m1\u001b[39m, y\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m2\u001b[39m), \u001b[38;5;28mdict\u001b[39m(x\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m3\u001b[39m, y\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m4\u001b[39m)])\n\u001b[1;32m      2\u001b[0m rgt_df \u001b[38;5;241m=\u001b[39m spark\u001b[38;5;241m.\u001b[39mcreateDataFrame([\u001b[38;5;28mdict\u001b[39m(x\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m1\u001b[39m)])\n\u001b[0;32m----> 3\u001b[0m \u001b[43msk\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcheck_row_count_equal\u001b[49m\u001b[43m(\u001b[49m\u001b[43mlft_df\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mrgt_df\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m/workspaces/onekit/src/onekit/sparkkit.py:255\u001b[0m, in \u001b[0;36mcheck_row_count_equal\u001b[0;34m(lft_df, rgt_df)\u001b[0m\n\u001b[1;32m    252\u001b[0m n_rgt \u001b[38;5;241m=\u001b[39m rgt_df\u001b[38;5;241m.\u001b[39mcount()\n\u001b[1;32m    254\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m n_lft \u001b[38;5;241m!=\u001b[39m n_rgt:\n\u001b[0;32m--> 255\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m RowCountMismatchError(n_lft, n_rgt)\n",
+      "Cell \u001b[0;32mIn[26], line 3\u001b[0m\n\u001b[1;32m      1\u001b[0m lft_df \u001b[38;5;241m=\u001b[39m spark\u001b[38;5;241m.\u001b[39mcreateDataFrame([\u001b[38;5;28mdict\u001b[39m(x\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m1\u001b[39m, y\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m2\u001b[39m), \u001b[38;5;28mdict\u001b[39m(x\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m3\u001b[39m, y\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m4\u001b[39m)])\n\u001b[1;32m      2\u001b[0m rgt_df \u001b[38;5;241m=\u001b[39m spark\u001b[38;5;241m.\u001b[39mcreateDataFrame([\u001b[38;5;28mdict\u001b[39m(x\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m1\u001b[39m)])\n\u001b[0;32m----> 3\u001b[0m \u001b[43msk\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43massert_row_count_equal\u001b[49m\u001b[43m(\u001b[49m\u001b[43mlft_df\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mrgt_df\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m/workspaces/onekit/src/onekit/sparkkit.py:245\u001b[0m, in \u001b[0;36massert_row_count_equal\u001b[0;34m(lft_df, rgt_df)\u001b[0m\n\u001b[1;32m    242\u001b[0m n_rgt \u001b[38;5;241m=\u001b[39m rgt_df\u001b[38;5;241m.\u001b[39mcount()\n\u001b[1;32m    244\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m n_lft \u001b[38;5;241m!=\u001b[39m n_rgt:\n\u001b[0;32m--> 245\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m RowCountMismatchError(n_lft, n_rgt)\n",
       "\u001b[0;31mRowCountMismatchError\u001b[0m: n_lft=2, n_rgt=1, n_diff=1"
      ]
     }
@@ -844,14 +844,14 @@
    "source": [
     "lft_df = spark.createDataFrame([dict(x=1, y=2), dict(x=3, y=4)])\n",
     "rgt_df = spark.createDataFrame([dict(x=1)])\n",
-    "sk.check_row_count_equal(lft_df, rgt_df)"
+    "sk.assert_row_count_equal(lft_df, rgt_df)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### `check_row_equal`"
+    "### `assert_row_equal`"
    ]
   },
   {
@@ -866,8 +866,8 @@
      "traceback": [
       "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
       "\u001b[0;31mRowMismatchError\u001b[0m                          Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[27], line 3\u001b[0m\n\u001b[1;32m      1\u001b[0m lft_df \u001b[38;5;241m=\u001b[39m spark\u001b[38;5;241m.\u001b[39mcreateDataFrame([\u001b[38;5;28mdict\u001b[39m(x\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m1\u001b[39m, y\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m2\u001b[39m), \u001b[38;5;28mdict\u001b[39m(x\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m3\u001b[39m, y\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m4\u001b[39m)])\n\u001b[1;32m      2\u001b[0m rgt_df \u001b[38;5;241m=\u001b[39m spark\u001b[38;5;241m.\u001b[39mcreateDataFrame([\u001b[38;5;28mdict\u001b[39m(x\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m3\u001b[39m, y\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m4\u001b[39m), \u001b[38;5;28mdict\u001b[39m(x\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m5\u001b[39m, y\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m6\u001b[39m), \u001b[38;5;28mdict\u001b[39m(x\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m7\u001b[39m, y\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m8\u001b[39m)])\n\u001b[0;32m----> 3\u001b[0m \u001b[43msk\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcheck_row_equal\u001b[49m\u001b[43m(\u001b[49m\u001b[43mlft_df\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mrgt_df\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m/workspaces/onekit/src/onekit/sparkkit.py:298\u001b[0m, in \u001b[0;36mcheck_row_equal\u001b[0;34m(lft_df, rgt_df)\u001b[0m\n\u001b[1;32m    295\u001b[0m is_equal \u001b[38;5;241m=\u001b[39m (n_lft \u001b[38;5;241m==\u001b[39m \u001b[38;5;241m0\u001b[39m) \u001b[38;5;129;01mand\u001b[39;00m (n_rgt \u001b[38;5;241m==\u001b[39m \u001b[38;5;241m0\u001b[39m)\n\u001b[1;32m    297\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m is_equal:\n\u001b[0;32m--> 298\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m RowMismatchError(lft_rows, rgt_rows, n_lft, n_rgt)\n",
+      "Cell \u001b[0;32mIn[27], line 3\u001b[0m\n\u001b[1;32m      1\u001b[0m lft_df \u001b[38;5;241m=\u001b[39m spark\u001b[38;5;241m.\u001b[39mcreateDataFrame([\u001b[38;5;28mdict\u001b[39m(x\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m1\u001b[39m, y\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m2\u001b[39m), \u001b[38;5;28mdict\u001b[39m(x\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m3\u001b[39m, y\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m4\u001b[39m)])\n\u001b[1;32m      2\u001b[0m rgt_df \u001b[38;5;241m=\u001b[39m spark\u001b[38;5;241m.\u001b[39mcreateDataFrame([\u001b[38;5;28mdict\u001b[39m(x\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m3\u001b[39m, y\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m4\u001b[39m), \u001b[38;5;28mdict\u001b[39m(x\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m5\u001b[39m, y\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m6\u001b[39m), \u001b[38;5;28mdict\u001b[39m(x\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m7\u001b[39m, y\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m8\u001b[39m)])\n\u001b[0;32m----> 3\u001b[0m \u001b[43msk\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43massert_row_equal\u001b[49m\u001b[43m(\u001b[49m\u001b[43mlft_df\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mrgt_df\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m/workspaces/onekit/src/onekit/sparkkit.py:288\u001b[0m, in \u001b[0;36massert_row_equal\u001b[0;34m(lft_df, rgt_df)\u001b[0m\n\u001b[1;32m    285\u001b[0m is_equal \u001b[38;5;241m=\u001b[39m (n_lft \u001b[38;5;241m==\u001b[39m \u001b[38;5;241m0\u001b[39m) \u001b[38;5;129;01mand\u001b[39;00m (n_rgt \u001b[38;5;241m==\u001b[39m \u001b[38;5;241m0\u001b[39m)\n\u001b[1;32m    287\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m is_equal:\n\u001b[0;32m--> 288\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m RowMismatchError(lft_rows, rgt_rows, n_lft, n_rgt)\n",
       "\u001b[0;31mRowMismatchError\u001b[0m: n_lft=1, n_rgt=2"
      ]
     }
@@ -875,7 +875,7 @@
    "source": [
     "lft_df = spark.createDataFrame([dict(x=1, y=2), dict(x=3, y=4)])\n",
     "rgt_df = spark.createDataFrame([dict(x=3, y=4), dict(x=5, y=6), dict(x=7, y=8)])\n",
-    "sk.check_row_equal(lft_df, rgt_df)"
+    "sk.assert_row_equal(lft_df, rgt_df)"
    ]
   },
   {

--- a/src/onekit/sparkkit.py
+++ b/src/onekit/sparkkit.py
@@ -27,7 +27,7 @@ __all__ = (
     "add_suffix",
     "assert_dataframe_equal",
     "assert_row_count_equal",
-    "check_row_equal",
+    "assert_row_equal",
     "check_schema_equal",
     "count_nulls",
     "cvf",
@@ -160,7 +160,7 @@ def assert_dataframe_equal(lft_df: SparkDF, rgt_df: SparkDF, /) -> None:
     --------
     check_schema_equal : Validate schemas.
     assert_row_count_equal : Validate row counts.
-    check_row_equal : Validate rows.
+    assert_row_equal : Validate rows.
 
     Examples
     --------
@@ -204,7 +204,7 @@ def assert_dataframe_equal(lft_df: SparkDF, rgt_df: SparkDF, /) -> None:
     """
     check_schema_equal(lft_df, rgt_df)
     assert_row_count_equal(lft_df, rgt_df)
-    check_row_equal(lft_df, rgt_df)
+    assert_row_equal(lft_df, rgt_df)
 
 
 def assert_row_count_equal(lft_df: SparkDF, rgt_df: SparkDF, /) -> None:
@@ -245,7 +245,7 @@ def assert_row_count_equal(lft_df: SparkDF, rgt_df: SparkDF, /) -> None:
         raise RowCountMismatchError(n_lft, n_rgt)
 
 
-def check_row_equal(lft_df: SparkDF, rgt_df: SparkDF, /) -> None:
+def assert_row_equal(lft_df: SparkDF, rgt_df: SparkDF, /) -> None:
     """Validate rows of both dataframes are equal.
 
     Raises
@@ -264,13 +264,13 @@ def check_row_equal(lft_df: SparkDF, rgt_df: SparkDF, /) -> None:
     >>> spark = SparkSession.builder.getOrCreate()
     >>> lft_df = spark.createDataFrame([dict(x=1, y=2), dict(x=3, y=4)])
     >>> rgt_df = spark.createDataFrame([dict(x=1, y=2), dict(x=3, y=4)])
-    >>> sk.check_row_equal(lft_df, rgt_df) is None
+    >>> sk.assert_row_equal(lft_df, rgt_df) is None
     True
 
     >>> lft_df = spark.createDataFrame([dict(x=1, y=2), dict(x=3, y=4)])
     >>> rgt_df = spark.createDataFrame([dict(x=3, y=4), dict(x=5, y=6), dict(x=7, y=8)])
     >>> try:
-    ...     sk.check_row_equal(lft_df, rgt_df)
+    ...     sk.assert_row_equal(lft_df, rgt_df)
     ... except sk.RowMismatchError as error:
     ...     print(error)
     ...
@@ -512,7 +512,7 @@ def is_dataframe_equal(lft_df: SparkDF, rgt_df: SparkDF, /) -> bool:
     try:
         check_schema_equal(lft_df, rgt_df)
         assert_row_count_equal(lft_df, rgt_df)
-        check_row_equal(lft_df, rgt_df)
+        assert_row_equal(lft_df, rgt_df)
         return True
     except SparkkitError:
         return False
@@ -570,7 +570,7 @@ def is_row_equal(lft_df: SparkDF, rgt_df: SparkDF, /) -> bool:
     False
     """
     try:
-        check_row_equal(lft_df, rgt_df)
+        assert_row_equal(lft_df, rgt_df)
         return True
     except RowMismatchError:
         return False

--- a/src/onekit/sparkkit.py
+++ b/src/onekit/sparkkit.py
@@ -26,7 +26,7 @@ __all__ = (
     "add_prefix",
     "add_suffix",
     "assert_dataframe_equal",
-    "check_row_count_equal",
+    "assert_row_count_equal",
     "check_row_equal",
     "check_schema_equal",
     "count_nulls",
@@ -159,7 +159,7 @@ def assert_dataframe_equal(lft_df: SparkDF, rgt_df: SparkDF, /) -> None:
     See Also
     --------
     check_schema_equal : Validate schemas.
-    check_row_count_equal : Validate row counts.
+    assert_row_count_equal : Validate row counts.
     check_row_equal : Validate rows.
 
     Examples
@@ -203,11 +203,11 @@ def assert_dataframe_equal(lft_df: SparkDF, rgt_df: SparkDF, /) -> None:
     n_lft=2, n_rgt=2
     """
     check_schema_equal(lft_df, rgt_df)
-    check_row_count_equal(lft_df, rgt_df)
+    assert_row_count_equal(lft_df, rgt_df)
     check_row_equal(lft_df, rgt_df)
 
 
-def check_row_count_equal(lft_df: SparkDF, rgt_df: SparkDF, /) -> None:
+def assert_row_count_equal(lft_df: SparkDF, rgt_df: SparkDF, /) -> None:
     """Validate row counts of both dataframes are equal.
 
     Raises
@@ -226,13 +226,13 @@ def check_row_count_equal(lft_df: SparkDF, rgt_df: SparkDF, /) -> None:
     >>> spark = SparkSession.builder.getOrCreate()
     >>> lft_df = spark.createDataFrame([dict(x=1, y=2), dict(x=3, y=4)])
     >>> rgt_df = spark.createDataFrame([dict(x=1, y=2), dict(x=3, y=4)])
-    >>> sk.check_row_count_equal(lft_df, rgt_df) is None
+    >>> sk.assert_row_count_equal(lft_df, rgt_df) is None
     True
 
     >>> lft_df = spark.createDataFrame([dict(x=1, y=2), dict(x=3, y=4)])
     >>> rgt_df = spark.createDataFrame([dict(x=1)])
     >>> try:
-    ...     sk.check_row_count_equal(lft_df, rgt_df)
+    ...     sk.assert_row_count_equal(lft_df, rgt_df)
     ... except sk.RowCountMismatchError as error:
     ...     print(error)
     ...
@@ -511,7 +511,7 @@ def is_dataframe_equal(lft_df: SparkDF, rgt_df: SparkDF, /) -> bool:
     """
     try:
         check_schema_equal(lft_df, rgt_df)
-        check_row_count_equal(lft_df, rgt_df)
+        assert_row_count_equal(lft_df, rgt_df)
         check_row_equal(lft_df, rgt_df)
         return True
     except SparkkitError:
@@ -541,7 +541,7 @@ def is_row_count_equal(lft_df: SparkDF, rgt_df: SparkDF, /) -> bool:
     False
     """
     try:
-        check_row_count_equal(lft_df, rgt_df)
+        assert_row_count_equal(lft_df, rgt_df)
         return True
     except RowCountMismatchError:
         return False

--- a/src/onekit/sparkkit.py
+++ b/src/onekit/sparkkit.py
@@ -28,7 +28,7 @@ __all__ = (
     "assert_dataframe_equal",
     "assert_row_count_equal",
     "assert_row_equal",
-    "check_schema_equal",
+    "assert_schema_equal",
     "count_nulls",
     "cvf",
     "daterange",
@@ -158,7 +158,7 @@ def assert_dataframe_equal(lft_df: SparkDF, rgt_df: SparkDF, /) -> None:
 
     See Also
     --------
-    check_schema_equal : Validate schemas.
+    assert_schema_equal : Validate schemas.
     assert_row_count_equal : Validate row counts.
     assert_row_equal : Validate rows.
 
@@ -202,7 +202,7 @@ def assert_dataframe_equal(lft_df: SparkDF, rgt_df: SparkDF, /) -> None:
     ...
     n_lft=2, n_rgt=2
     """
-    check_schema_equal(lft_df, rgt_df)
+    assert_schema_equal(lft_df, rgt_df)
     assert_row_count_equal(lft_df, rgt_df)
     assert_row_equal(lft_df, rgt_df)
 
@@ -288,7 +288,7 @@ def assert_row_equal(lft_df: SparkDF, rgt_df: SparkDF, /) -> None:
         raise RowMismatchError(lft_rows, rgt_rows, n_lft, n_rgt)
 
 
-def check_schema_equal(lft_df: SparkDF, rgt_df: SparkDF, /) -> None:
+def assert_schema_equal(lft_df: SparkDF, rgt_df: SparkDF, /) -> None:
     """Validate schemas of both dataframes are equal.
 
     Raises
@@ -307,13 +307,13 @@ def check_schema_equal(lft_df: SparkDF, rgt_df: SparkDF, /) -> None:
     >>> spark = SparkSession.builder.getOrCreate()
     >>> lft_df = spark.createDataFrame([dict(x=1, y=2), dict(x=3, y=4)])
     >>> rgt_df = spark.createDataFrame([dict(x=1, y=2), dict(x=3, y=4)])
-    >>> sk.check_schema_equal(lft_df, rgt_df) is None
+    >>> sk.assert_schema_equal(lft_df, rgt_df) is None
     True
 
     >>> lft_df = spark.createDataFrame([dict(x=1, y=2), dict(x=3, y=4)])
     >>> rgt_df = spark.createDataFrame([dict(x=1), dict(x=3)])
     >>> try:
-    ...     sk.check_schema_equal(lft_df, rgt_df)
+    ...     sk.assert_schema_equal(lft_df, rgt_df)
     ... except sk.SchemaMismatchError as error:
     ...     print(error)
     ...
@@ -510,7 +510,7 @@ def is_dataframe_equal(lft_df: SparkDF, rgt_df: SparkDF, /) -> bool:
     False
     """
     try:
-        check_schema_equal(lft_df, rgt_df)
+        assert_schema_equal(lft_df, rgt_df)
         assert_row_count_equal(lft_df, rgt_df)
         assert_row_equal(lft_df, rgt_df)
         return True
@@ -599,7 +599,7 @@ def is_schema_equal(lft_df: SparkDF, rgt_df: SparkDF, /) -> bool:
     False
     """
     try:
-        check_schema_equal(lft_df, rgt_df)
+        assert_schema_equal(lft_df, rgt_df)
         return True
     except SchemaMismatchError:
         return False

--- a/src/onekit/sparkkit.py
+++ b/src/onekit/sparkkit.py
@@ -25,7 +25,7 @@ import onekit.pythonkit as pk
 __all__ = (
     "add_prefix",
     "add_suffix",
-    "check_dataframe_equal",
+    "assert_dataframe_equal",
     "check_row_count_equal",
     "check_row_equal",
     "check_schema_equal",
@@ -144,7 +144,7 @@ def add_suffix(suffix: str, /, *, subset=None) -> SparkDFTransformFunc:
     return inner
 
 
-def check_dataframe_equal(lft_df: SparkDF, rgt_df: SparkDF, /) -> None:
+def assert_dataframe_equal(lft_df: SparkDF, rgt_df: SparkDF, /) -> None:
     """Validate both dataframes are equal.
 
     Raises
@@ -169,13 +169,13 @@ def check_dataframe_equal(lft_df: SparkDF, rgt_df: SparkDF, /) -> None:
     >>> spark = SparkSession.builder.getOrCreate()
     >>> lft_df = spark.createDataFrame([Row(x=1, y=2), Row(x=3, y=4)])
     >>> rgt_df = spark.createDataFrame([Row(x=1, y=2), Row(x=3, y=4)])
-    >>> sk.check_dataframe_equal(lft_df, rgt_df) is None
+    >>> sk.assert_dataframe_equal(lft_df, rgt_df) is None
     True
 
     >>> lft_df = spark.createDataFrame([Row(x=1, y=2), Row(x=3, y=4)])
     >>> rgt_df = spark.createDataFrame([Row(z=1, y="a", x=9), Row(z=3, y="b", x=8)])
     >>> try:
-    ...     sk.check_dataframe_equal(lft_df, rgt_df)
+    ...     sk.assert_dataframe_equal(lft_df, rgt_df)
     ... except sk.SchemaMismatchError as error:
     ...     print(error)
     ...
@@ -187,7 +187,7 @@ def check_dataframe_equal(lft_df: SparkDF, rgt_df: SparkDF, /) -> None:
     >>> lft_df = spark.createDataFrame([Row(x=1, y=2)])
     >>> rgt_df = spark.createDataFrame([Row(x=3, y=4), Row(x=5, y=6)])
     >>> try:
-    ...     sk.check_dataframe_equal(lft_df, rgt_df)
+    ...     sk.assert_dataframe_equal(lft_df, rgt_df)
     ... except sk.RowCountMismatchError as error:
     ...     print(error)
     ...
@@ -196,7 +196,7 @@ def check_dataframe_equal(lft_df: SparkDF, rgt_df: SparkDF, /) -> None:
     >>> lft_df = spark.createDataFrame([Row(x=1, y=2), Row(x=3, y=4), Row(x=5, y=6)])
     >>> rgt_df = spark.createDataFrame([Row(x=3, y=4), Row(x=5, y=9), Row(x=7, y=8)])
     >>> try:
-    ...     sk.check_dataframe_equal(lft_df, rgt_df)
+    ...     sk.assert_dataframe_equal(lft_df, rgt_df)
     ... except sk.RowMismatchError as error:
     ...     print(error)
     ...
@@ -217,7 +217,7 @@ def check_row_count_equal(lft_df: SparkDF, rgt_df: SparkDF, /) -> None:
 
     See Also
     --------
-    check_dataframe_equal : Validate dataframes.
+    assert_dataframe_equal : Validate dataframes.
 
     Examples
     --------
@@ -255,7 +255,7 @@ def check_row_equal(lft_df: SparkDF, rgt_df: SparkDF, /) -> None:
 
     See Also
     --------
-    check_dataframe_equal : Validate dataframes.
+    assert_dataframe_equal : Validate dataframes.
 
     Examples
     --------
@@ -298,7 +298,7 @@ def check_schema_equal(lft_df: SparkDF, rgt_df: SparkDF, /) -> None:
 
     See Also
     --------
-    check_dataframe_equal : Validate dataframes.
+    assert_dataframe_equal : Validate dataframes.
 
     Examples
     --------

--- a/tests/test_sparkkit.py
+++ b/tests/test_sparkkit.py
@@ -70,16 +70,16 @@ class TestSparkKit:
 
         assert sk.assert_dataframe_equal(lft_df, rgt_df) is None
 
-    def test_check_row_count_equal(self, spark: SparkSession):
+    def test_assert_row_count_equal(self, spark: SparkSession):
         lft_df = spark.createDataFrame([Row(x=1, y=2), Row(x=3, y=4)])
 
         rgt_df__equal = spark.createDataFrame([Row(x=1), Row(x=3)])
         rgt_df__different = spark.createDataFrame([Row(x=1)])
 
-        assert sk.check_row_count_equal(lft_df, rgt_df__equal) is None
+        assert sk.assert_row_count_equal(lft_df, rgt_df__equal) is None
 
         with pytest.raises(sk.RowCountMismatchError):
-            sk.check_row_count_equal(lft_df, rgt_df__different)
+            sk.assert_row_count_equal(lft_df, rgt_df__different)
 
     def test_check_row_equal(self, spark: SparkSession):
         lft_df = spark.createDataFrame([Row(x=1, y=2), Row(x=3, y=4)])

--- a/tests/test_sparkkit.py
+++ b/tests/test_sparkkit.py
@@ -92,7 +92,7 @@ class TestSparkKit:
         with pytest.raises(sk.RowMismatchError):
             sk.assert_row_equal(lft_df, rgt_df__different)
 
-    def test_check_schema_equal(self, spark: SparkSession):
+    def test_assert_schema_equal(self, spark: SparkSession):
         lft_df = spark.createDataFrame([Row(x=1, y=2), Row(x=3, y=4)])
 
         rgt_df__equal = spark.createDataFrame([Row(x=1, y=2), Row(x=3, y=4)])
@@ -101,13 +101,13 @@ class TestSparkKit:
         )
         rgt_df__different_size = spark.createDataFrame([Row(x=1), Row(x=3)])
 
-        assert sk.check_schema_equal(lft_df, rgt_df__equal) is None
+        assert sk.assert_schema_equal(lft_df, rgt_df__equal) is None
 
         with pytest.raises(sk.SchemaMismatchError):
-            sk.check_schema_equal(lft_df, rgt_df__different_type)
+            sk.assert_schema_equal(lft_df, rgt_df__different_type)
 
         with pytest.raises(sk.SchemaMismatchError):
-            sk.check_schema_equal(lft_df, rgt_df__different_size)
+            sk.assert_schema_equal(lft_df, rgt_df__different_size)
 
     def test_count_nulls(self, spark: SparkSession):
         df = spark.createDataFrame(

--- a/tests/test_sparkkit.py
+++ b/tests/test_sparkkit.py
@@ -64,11 +64,11 @@ class TestSparkKit:
         expected = spark.createDataFrame([Row(a=1, b_sfx=2)])
         self.assert_dataframe_equal(actual, expected)
 
-    def test_check_dataframe_equal(self, spark: SparkSession):
+    def test_assert_dataframe_equal(self, spark: SparkSession):
         lft_df = spark.createDataFrame([Row(x=1, y=2), Row(x=3, y=4)])
         rgt_df = spark.createDataFrame([Row(x=1, y=2), Row(x=3, y=4)])
 
-        assert sk.check_dataframe_equal(lft_df, rgt_df) is None
+        assert sk.assert_dataframe_equal(lft_df, rgt_df) is None
 
     def test_check_row_count_equal(self, spark: SparkSession):
         lft_df = spark.createDataFrame([Row(x=1, y=2), Row(x=3, y=4)])
@@ -529,7 +529,7 @@ class TestSparkKit:
     @staticmethod
     def assert_dataframe_equal(lft_df: SparkDF, rgt_df: SparkDF) -> None:
         """Assert that the left and right data frames are equal."""
-        sk.check_dataframe_equal(lft_df, rgt_df)
+        sk.assert_dataframe_equal(lft_df, rgt_df)
 
     @pytest.fixture(scope="class")
     def spark(self) -> SparkSession:

--- a/tests/test_sparkkit.py
+++ b/tests/test_sparkkit.py
@@ -81,16 +81,16 @@ class TestSparkKit:
         with pytest.raises(sk.RowCountMismatchError):
             sk.assert_row_count_equal(lft_df, rgt_df__different)
 
-    def test_check_row_equal(self, spark: SparkSession):
+    def test_assert_row_equal(self, spark: SparkSession):
         lft_df = spark.createDataFrame([Row(x=1, y=2), Row(x=3, y=4)])
 
         rgt_df__equal = spark.createDataFrame([Row(x=1, y=2), Row(x=3, y=4)])
         rgt_df__different = spark.createDataFrame([Row(x=1, y=7), Row(x=3, y=9)])
 
-        assert sk.check_row_equal(lft_df, rgt_df__equal) is None
+        assert sk.assert_row_equal(lft_df, rgt_df__equal) is None
 
         with pytest.raises(sk.RowMismatchError):
-            sk.check_row_equal(lft_df, rgt_df__different)
+            sk.assert_row_equal(lft_df, rgt_df__different)
 
     def test_check_schema_equal(self, spark: SparkSession):
         lft_df = spark.createDataFrame([Row(x=1, y=2), Row(x=3, y=4)])


### PR DESCRIPTION
Rename:

- check_schema_equal -> assert_schema_equal 
- check_row_equal -> assert_row_equal
- check_row_count_equal -> assert_row_count_equal 
- check_dataframe_equal -> assert_dataframe_equal

BREAKING CHANGE: Rename validation functions